### PR TITLE
Incorporate geek feminism org

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,10 +44,11 @@ Please send us a pull request with your suggestions.
 
 ## Thanks
 
-We all stand on the shoulders of giants across many open source communities. 
+We all stand on the shoulders of giants across many open source communities.
 
 We'd like to thank the communities and projects that established code of conducts and diversity statements as our inspiration:
 * Django: https://www.djangoproject.com/conduct/reporting/
 * Python: https://www.python.org/community/diversity/
 * Ubuntu: http://www.ubuntu.com/about/about-ubuntu/conduct
 * Contributor Covenant: http://contributor-covenant.org/
+* Geek Feminism: http://geekfeminism.org/about/code-of-conduct/

--- a/index.md
+++ b/index.md
@@ -28,10 +28,10 @@ should make it known and take the proper steps to ensure that others can pick up
 Harassment includes:
 
 - Offensive comments related to gender, gender identity and expression, sexual orientation, disability, mental illness, neuro(a)typicality, physical appearance, body size, race, or religion
-- Unwelcome comments regarding a person’s lifestyle choices and practices, including those related to food, health, parenting, drugs, and employment.
+- Unwelcome comments regarding a person’s lifestyle choices and practices, including those related to food, health, parenting, drugs, and employment
 - Deliberate misgendering or use of ‘dead’ or rejected names
 - Gratuitous or off-topic sexual images or behaviour  in spaces where they’re not appropriate
-- Physical contact and simulated physical contact (eg, textual descriptions like “*hug*” or “*backrub*”) without consent or after a request to stop.
+- Physical contact and simulated physical contact (eg, textual descriptions like “*hug*” or “*backrub*”) without consent or after a request to stop
 - Threats of violence
 - Incitement of violence towards any individual, including encouraging a person to commit suicide or to engage in self-harm
 - Deliberate intimidation

--- a/index.md
+++ b/index.md
@@ -2,7 +2,7 @@
 layout: default
 ---
 
-The purpose of creating this effort was to promote more open source organizations and projects to adopt code of conducts. Through our experiences at the [@TODOGroup](https://twitter.com/todogroup), we strongly believe that code of conducts help set the ground rules for participation in communities and more importantly, help build a culture of respect. We hope by [sharing this with you](https://github.com/opencodeofconduct/opencodeofconduct.github.io) will enable you to easily establish a code of conduct for your respective open source community. The following is a code of conduct template. To generate your own code of conduct, change the values of COMMUNITY, CONTACT from their original values as given here, and substitute your own._
+_The purpose of creating this effort was to promote more open source organizations and projects to adopt code of conducts. Through our experiences at the [@TODOGroup](https://twitter.com/todogroup), we strongly believe that code of conducts help set the ground rules for participation in communities and more importantly, help build a culture of respect. We hope by [sharing this with you](https://github.com/opencodeofconduct/opencodeofconduct.github.io) will enable you to easily establish a code of conduct for your respective open source community. The following is a code of conduct template. To generate your own code of conduct, change the values of COMMUNITY, CONTACT from their original values as given here, and substitute your own._
 
 ### Open Code of Conduct v1.0
 

--- a/index.md
+++ b/index.md
@@ -4,7 +4,7 @@ layout: default
 
 The purpose of creating this effort was to promote more open source organizations and projects to adopt code of conducts. Through our experiences at the [@TODOGroup](https://twitter.com/todogroup), we strongly believe that code of conducts help set the ground rules for participation in communities and more importantly, help build a culture of respect. We hope by [sharing this with you](https://github.com/opencodeofconduct/opencodeofconduct.github.io) will enable you to easily establish a code of conduct for your respective open source community. The following is a code of conduct template. To generate your own code of conduct, change the values of COMMUNITY, CONTACT from their original values as given here, and substitute your own._
 
-### Code of Conduct
+### Open Code of Conduct v1.0
 
 Our open source community is dedicated to providing a harassment-free experience for everyone. We do not tolerate harassment of participants in any form.
 

--- a/index.md
+++ b/index.md
@@ -2,47 +2,67 @@
 layout: default
 ---
 
-_The purpose of creating this effort was to promote more open source organizations and projects to adopt code of conducts. Through our experiences at the [@TODOGroup](https://twitter.com/todogroup), we strongly believe that code of conducts help set the ground rules for participation in communities and more importantly, help build a culture of respect. We hope by [sharing this with you](https://github.com/opencodeofconduct/opencodeofconduct.github.io) will enable you to easily establish a code of conduct for your respective open source community. The following is a code of conduct template. To generate your own code of conduct, change the values of COMMUNITY, CONTACT from their original values as given here, and substitute your own._
+_The purpose of creating this effort was to promote more open source organizations and projects to adopt code of conducts. Through our experiences at the [@TODOGroup](https://twitter.com/todogroup), we strongly believe that code of conducts help set the ground rules for participation in communities and more importantly, help build a culture of respect. We hope by [sharing this with you](https://github.com/opencodeofconduct/opencodeofconduct.github.io) will enable you to easily establish a code of conduct for your respective open source community._
 
-### Open Code of Conduct v1.0
 
-This code of conduct outlines our expectations for participants within the **[COMMUNITY]**, as well as steps to reporting unacceptable behavior. We are committed to providing a welcoming and inspiring community for all and expect our code of conduct to be honored.
+### Code of Conduct
+
+Our open source community is dedicated to providing a harassment-free experience for everyone. We do not tolerate harassment of participants in any form.
+
+Anyone who violates this code of conduct may be permanently banned from out community. This is at the discretion of [the Anti-Abuse team](/report-abuse.html).
+
+We are committed to providing a welcoming and inspiring community for all and expect our code of conduct to be honored.
 
 Our open source community strives to:
 
-* **Be friendly and patient.**
-* **Be welcoming**: We strive to be a community that welcomes and supports people of all backgrounds and identities. This includes, but is not limited to members of any race, ethnicity, culture, national origin, colour, immigration status, social and economic class, educational level, sex, sexual orientation, gender identity and expression, age, size, family status, political belief, religion, and mental and physical ability.
-* **Be considerate**: Your work will be used by other people, and you in turn will depend on the work of others. Any decision you take will affect users and colleagues, and you should take those consequences into account when making decisions. Remember that we're a world-wide community, so you might not be communicating in someone else's primary language.
-* **Be respectful**:  Not all of us will agree all the time, but disagreement is no excuse for poor behavior and poor manners. We might all experience some frustration now and then, but we cannot allow that frustration to turn into a personal attack. It’s important to remember that a community where people feel uncomfortable or threatened is not a productive one.
-* **Be careful in the words that you choose**: e are a community of professionals, and we conduct ourselves professionally. Be kind to others. Do not insult or put down other participants. Harassment and other exclusionary behavior aren't acceptable. This includes, but is not limited to:
-  * Violent threats or language directed against another person.
-  * Discriminatory jokes and language.
-  * Posting sexually explicit or violent material.
-  * Posting (or threatening to post) other people's personally identifying information ("doxing").
-  * Personal insults, especially those using racist or sexist terms.
-  * Unwelcome sexual attention.
-  * Advocating for, or encouraging, any of the above behavior.
-  * Repeated harassment of others. In general, if someone asks you to stop, then stop.
-* **When we disagree, try to understand why**: Disagreements, both social and technical, happen all the time. It is important that we resolve disagreements and differing views constructively. Remember that we’re different. The strength of our community comes from its diversity, people from a wide range of backgrounds. Different people have different perspectives on issues. Being unable to understand why someone holds a viewpoint doesn’t mean that they’re wrong. Don’t forget that it is human to err and blaming each other doesn’t get us anywhere. Instead, focus on helping to resolve issues and learning from mistakes.
+- **Be open**: We invite anyone to participate in any aspect of our projects. Our community is open, and any responsibility can be carried by any contributor.
+- **Be considerate**: People use our work, and we depend on the work of others. Consider users and colleagues before taking action. For example, changes to code, infrastructure, policy, and documentation may negatively impact others.
+- **Be respectful**: We expect people to work together to resolve conflict, assume good intentions, and act with empathy. Do not turn disagreements into personal attacks.
+- **Be collaborative**: Collaboration reduces redundancy and improves the quality of our work. We
+strive for transparency within our open source community, and we work closely with upstream developers and others in the free software community to coordinate our efforts.
+- **Be pragmatic**: Questions are encouraged and should be asked early in the process to avoid problems later. Be thoughtful and considerate when seeking out the appropriate forum for your questions. Those who are asked should be responsive and helpful.
+- **Step down considerately**: Members of every project come and go. When somebody leaves or disengages from the project, they
+should make it known and take the proper steps to ensure that others can pick up where they left off.
 
-This code is not exhaustive or complete. It serves to distill our common understanding of a collaborative, shared environment, and goals. We expect it to be followed in spirit as much as in the letter.
+### Definitions
 
-### Diversity Statement
+Harassment includes:
 
-We encourage everyone to participate and are committed to building a community for all. Although we may not be able to satisfy everyone, we all agree that everyone is equal. Whenever a participant has made a mistake, we expect them to take responsibility for it. If someone has been harmed or offended, it is our responsibility to listen carefully and respectfully, and do our best to right the wrong.
+- Offensive comments related to gender, gender identity and expression, sexual orientation, disability, mental illness, neuro(a)typicality, physical appearance, body size, race, or religion
+- Unwelcome comments regarding a person’s lifestyle choices and practices, including those related to food, health, parenting, drugs, and employment.
+- Deliberate misgendering or use of ‘dead’ or rejected names
+- Gratuitous or off-topic sexual images or behaviour  in spaces where they’re not appropriate
+- Physical contact and simulated physical contact (eg, textual descriptions like “*hug*” or “*backrub*”) without consent or after a request to stop.
+- Threats of violence
+- Incitement of violence towards any individual, including encouraging a person to commit suicide or to engage in self-harm
+- Deliberate intimidation
+- Stalking or following
+- Harassing photography or recording, including logging online activity for harassment purposes
+- Sustained disruption of discussion
+- Unwelcome sexual attention
+- Pattern of inappropriate social contact, such as requesting/assuming inappropriate levels of intimacy with others
+- Continued one-on-one communication after requests to cease
+- Deliberate “outing” of any aspect of a person’s identity without their consent except as necessary to protect other GF members or other vulnerable people from intentional abuse
+- Publication of non-harassing private communication
 
-Although this list cannot be exhaustive, we explicitly honor diversity in age, gender, gender identity or expression, culture, ethnicity, language, national origin, political beliefs, profession, race, religion, sexual orientation, socioeconomic status, and technical ability. We will not tolerate discrimination based on any of the protected
-characteristics above, including participants with disabilities.
+Our open source community prioritizes marginalized people’s safety over privileged people’s comfort. Our Anti-Abuse Team will not act on complaints regarding:
+
+- ‘Reverse’ -isms, including ‘reverse racism,’ ‘reverse sexism,’ and ‘cisphobia’ (because these things don’t exist)
+- Reasonable communication of boundaries, such as “leave me alone,” “go away,” or “I’m not discussing this with you.”
+- Refusal to explain or debate social justice concepts
+- Communicating in a ‘tone’ you don’t find congenial
+- Criticizing racist, sexist, cissexist, or otherwise oppressive behavior or assumptions
 
 ### Reporting Issues
 
-If you experience or witness unacceptable behavior—or have any other concerns—please report it by contacting us via **[CONTACT]**. All reports will be handled with discretion. In your report please include:
+If you experience or witness unacceptable behavior—or have any other concerns—please report it by emailing our Anti-Abuse team **[an email address]**. All reports will be handled with discretion. In your report please include:
 
 - Your contact information.
 - Names (real, nicknames, or pseudonyms) of any individuals involved. If there are additional witnesses, please
 include them as well. Your account of what occurred, and if you believe the incident is ongoing. If there is a publicly available record (e.g. a mailing list archive or a public IRC logger), please include a link.
 - Any additional information that may be helpful.
 
-After filing a report, a representative will contact you personally. The representative will then review the incident, follow up with any additional questions, and make a decision as to how to respond.
+After filing a report, a representative will contact you personally.  If the person who is harassing you is on the team, they will recuse themselves from handling your incident. A representative will then review the incident, follow up with any additional questions, and make a decision as to how to respond.
 
-Anyone asked to stop unacceptable behavior is expected to comply immediately. If an individual engages in unacceptable behavior, the representative may take any action they deem appropriate, up to and including a permanent ban from our community without warning.
+## Consequences
+Participants asked to stop any harassing behavior are expected to comply immediately. If an individual engages in unacceptable behavior, the representative may take any action they deem appropriate, up to and including a permanent ban from our community without warning.

--- a/index.md
+++ b/index.md
@@ -2,8 +2,7 @@
 layout: default
 ---
 
-_The purpose of creating this effort was to promote more open source organizations and projects to adopt code of conducts. Through our experiences at the [@TODOGroup](https://twitter.com/todogroup), we strongly believe that code of conducts help set the ground rules for participation in communities and more importantly, help build a culture of respect. We hope by [sharing this with you](https://github.com/opencodeofconduct/opencodeofconduct.github.io) will enable you to easily establish a code of conduct for your respective open source community._
-
+The purpose of creating this effort was to promote more open source organizations and projects to adopt code of conducts. Through our experiences at the [@TODOGroup](https://twitter.com/todogroup), we strongly believe that code of conducts help set the ground rules for participation in communities and more importantly, help build a culture of respect. We hope by [sharing this with you](https://github.com/opencodeofconduct/opencodeofconduct.github.io) will enable you to easily establish a code of conduct for your respective open source community. The following is a code of conduct template. To generate your own code of conduct, change the values of COMMUNITY, CONTACT from their original values as given here, and substitute your own._
 
 ### Code of Conduct
 

--- a/report-abuse.md
+++ b/report-abuse.md
@@ -1,0 +1,30 @@
+---
+layout: default
+---
+
+### Report Abuse
+Our open source community is dedicated to providing a harassment-free experience for everyone, regardless of gender, gender identity and expression, sexual orientation, disability, physical appearance, body size, race, or religion. We do not tolerate harassment of participants in any form.
+
+Please review our Code of Conduct for our definition of harassment.
+
+##### ANTI-ABUSE TEAM:
+
+The current Anti-Abuse Team is:
+
+- **Team members name**
+- **Team members name**
+
+The Anti-Abuse team email address is **[an email address]**
+
+### REPORTING:
+
+If you are being harassed by a member of our open source community, notice that someone else is being harassed, or have any other concerns, please contact the Anti-Abuse Team at **[An email address]**.
+
+If the person who is harassing you is on the team, they will recuse themselves from handling your incident. We will respond as promptly as we can.
+
+Please do not reach out to the Anti-Abuse Team via their private email addresses or social media accounts. If your report does not come through  **[An email address]**, we cannot guarantee that it will be seen and addressed.
+
+
+### CONFIDENTIALITY:
+
+We will respect confidentiality requests for the purpose of protecting victims of abuse. At our discretion, we may publicly name a person about whom we’ve received harassment complaints, or privately warn third parties about them, if we believe that doing so will increase the safety of our community memvers members or the general public. We will not name harassment victims without their affirmative consent.

--- a/report-abuse.md
+++ b/report-abuse.md
@@ -5,24 +5,24 @@ layout: default
 ### Report Abuse
 Our open source community is dedicated to providing a harassment-free experience for everyone, regardless of gender, gender identity and expression, sexual orientation, disability, physical appearance, body size, race, or religion. We do not tolerate harassment of participants in any form.
 
-Please review our Code of Conduct for our definition of harassment.
+Please review our [Code of Conduct ](/code-of-conduct.html) for our definition of harassment.
 
 ##### ANTI-ABUSE TEAM:
 
 The current Anti-Abuse Team is:
 
-- **Team members name**
-- **Team members name**
+- **Team member name**
+- **Team member name**
 
-The Anti-Abuse team email address is **[an email address]**
+The Anti-Abuse team email address is **[ABUSE EMAIL ADDRESS]**
 
 ### REPORTING:
 
-If you are being harassed by a member of our open source community, notice that someone else is being harassed, or have any other concerns, please contact the Anti-Abuse Team at **[An email address]**.
+If you are being harassed by a member of our open source community, notice that someone else is being harassed, or have any other concerns, please contact the Anti-Abuse Team at **[ABUSE EMAIL ADDRESS]**.
 
 If the person who is harassing you is on the team, they will recuse themselves from handling your incident. We will respond as promptly as we can.
 
-Please do not reach out to the Anti-Abuse Team via their private email addresses or social media accounts. If your report does not come through  **[An email address]**, we cannot guarantee that it will be seen and addressed.
+Please do not reach out to the Anti-Abuse Team via their private email addresses or social media accounts. If your report does not come through **[ABUSE EMAIL ADDRESS]**, we cannot guarantee that it will be seen and addressed.
 
 
 ### CONFIDENTIALITY:

--- a/report-abuse.md
+++ b/report-abuse.md
@@ -27,4 +27,4 @@ Please do not reach out to the Anti-Abuse Team via their private email addresses
 
 ### CONFIDENTIALITY:
 
-We will respect confidentiality requests for the purpose of protecting victims of abuse. At our discretion, we may publicly name a person about whom we’ve received harassment complaints, or privately warn third parties about them, if we believe that doing so will increase the safety of our community memvers members or the general public. We will not name harassment victims without their affirmative consent.
+We will respect confidentiality requests for the purpose of protecting victims of abuse. At our discretion, we may publicly name a person about whom we’ve received harassment complaints, or privately warn third parties about them, if we believe that doing so will increase the safety of our community members or the general public. We will not name harassment victims without their affirmative consent.


### PR DESCRIPTION
:wave:

As discussed here https://github.com/github/opencodeofconduct.github.io/pull/1

I had a go at incorporating the explicit definitions of harassment found here http://geekfeminism.wikia.com/wiki/Community_anti-harassment/Policy

One thing I really like about the GF code of conduct is that there is a secondary document which allows the definition and formation of an Anti Abuse Team. I have included that also.

This is ready for :eyes: and feedback cc @bkeepers @caniszczyk  
