### PR TITLE
Make placeholders configurable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 _site
+.sass-cache

--- a/_layouts/code-of-conduct.html
+++ b/_layouts/code-of-conduct.html
@@ -2,19 +2,20 @@
 layout: default
 ---
 
-<p><i>The purpose of creating this effort was to promote more open source
-  organizations and projects to adopt code of conducts. Through our experiences
-  at the [@TODOGroup](https://twitter.com/todogroup), we strongly believe that
-  code of conducts help set the ground rules for participation in communities and
-  more importantly, help build a culture of respect. We hope by [sharing this
-  with you](https://github.com/opencodeofconduct/opencodeofconduct.github.io)
-  will enable you to easily establish a code of conduct for your respective
-  open source community. The following is a code of conduct template. To
-  generate your own code of conduct, change the values of COMMUNITY, CONTACT
-  from their original values as given here, and substitute your own.</i></p>
-
 <div id="configure" class="unconfigured">
-  <a href="#configure" class="show-when-configured show-when-unconfigured">Configure</a>
+  <p class="show-when-unconfigured"><i>The purpose of creating this effort was to promote more open source
+    organizations and projects to adopt code of conducts. Through our experiences
+    at the <a href="https://twitter.com/todogroup">@TODOGroup</a>, we strongly believe that
+    code of conducts help set the ground rules for participation in communities and
+    more importantly, help build a culture of respect. We hope by <a href="https://github.com/opencodeofconduct/opencodeofconduct.github.io">sharing this
+    with you</a>
+    will enable you to easily establish a code of conduct for your respective
+    open source community. The following is a code of conduct template. To
+    generate your own code of conduct, change the values of COMMUNITY, CONTACT
+    from their original values as given here, and substitute your own.</i></p>
+
+
+  <a href="#configure" class="show-when-unconfigured">Configure</a>
 
   <form class="show-when-configuring">
     <p>

--- a/_layouts/code-of-conduct.html
+++ b/_layouts/code-of-conduct.html
@@ -2,38 +2,51 @@
 layout: default
 ---
 
+</div> <!-- .container -->
+
 <div id="configure" class="unconfigured">
-  <p id="intro" class="show-when-unconfigured">Through our experiences at the <a href="http://todogroup.org">TODO Group</a>, we strongly believe that a code of conduct helps set the ground rules for participation in communities and helps build a culture of respect. We hope <a href="https://github.com/todogroup/opencodeofconduct">sharing this with you</a> will enable you to easily establish a code of conduct for your respective open source community. The following is a code of conduct template. To generate your own code of conduct, change the values of COMMUNITY, CONTACT from their original values as given here, and substitute your own.</p>
+  <div class="container">
+  <div>
+    <p>Through our experiences at the <a href="http://todogroup.org">TODO Group</a>, we strongly believe that a code of conduct helps set the ground rules for participation in communities and helps build a culture of respect. We hope <a href="https://github.com/todogroup/opencodeofconduct">sharing this with you</a> will enable you to easily establish a code of conduct for your respective open source community.</p>
 
-  <a href="#configure" class="show-when-unconfigured">Configure</a>
+    <ol>
+      <li>
+        <h2>Configure the Code of Conduct:</h2>
+        <form>
+          <ul>
+            <li>
+              <label>What is the name of your community?</label>
+              <div><input type="text" name="community" placeholder="TODO Group" required></div>
+            </li>
 
-  <form class="show-when-configuring">
-    <p>
-      <label>Name of community:</label>
-      <input type="text" name="community">
-    </p>
+            <li>
+              <label>Where should abuses be reported to?</label>
+              <div><input type="email" name="contact" placeholder="abuse@todogroup.org" required></div>
+            </li>
+          </ul>
+        </form>
+      </li>
+      <li id="apply" class="show-when-configured">
+        <h2>Apply it to your community:</h2>
 
-    <p>
-      <label>Email address to report abuses to:</label>
-      <input type="email" name="contact">
-    </p>
+        <p>Copy and paste this template into the <code>README</code> or <code>CONTRIBUTING</code> file of your project.</p>
 
-    <button>Configure</button>
-  </form>
+        <textarea id="snippet" disabled></textarea>
 
-
-  <div id="apply" class="show-when-configured">
-    <p>Copy and paste this template into the <code>README</code> or <code>CONTRIBUTING</code> file of your project.</p>
-
-    <textarea id="snippet"></textarea>
-
-    <div id="code"></div>
+        <div id="code"></div>
+      </li>
+    </ol>
   </div>
 
   <script id="markdown-template" type="text/plain">
-    This project adheres to the [Open Code of Conduct]([URL]). By participating, you are expected to uphold this code.
+This project adheres to the [Open Code of Conduct][code-of-conduct]. By participating, you are expected to uphold this code.
+[code-of-conduct]: [URL]
   </script>
+
+  </div> <!-- .container -->
 </div>
+
+<div class="container">
 
 <div id="code-of-conduct">
   {{ content }}

--- a/_layouts/code-of-conduct.html
+++ b/_layouts/code-of-conduct.html
@@ -29,7 +29,7 @@ layout: default
       <li id="apply" class="show-when-configured">
         <h2>Apply it to your community:</h2>
 
-        <p>Copy and paste this template into the <code>README</code> or <code>CONTRIBUTING</code> file of your project.</p>
+        <p>Copy this template into the <code>README</code> or <code>CONTRIBUTING</code> file of your project.</p>
 
         <textarea id="snippet" disabled></textarea>
 

--- a/_layouts/code-of-conduct.html
+++ b/_layouts/code-of-conduct.html
@@ -36,6 +36,8 @@ layout: default
         <div id="code"></div>
       </li>
     </ol>
+
+    <p>If this template doesn't fit your needs, feel free to <a href="https://github.com/todogroup/opencodeofconduct">adapt it to your community</a>.</p>
   </div>
 
   <script id="markdown-template" type="text/plain">

--- a/_layouts/code-of-conduct.html
+++ b/_layouts/code-of-conduct.html
@@ -1,0 +1,51 @@
+---
+layout: default
+---
+
+<p><i>The purpose of creating this effort was to promote more open source
+  organizations and projects to adopt code of conducts. Through our experiences
+  at the [@TODOGroup](https://twitter.com/todogroup), we strongly believe that
+  code of conducts help set the ground rules for participation in communities and
+  more importantly, help build a culture of respect. We hope by [sharing this
+  with you](https://github.com/opencodeofconduct/opencodeofconduct.github.io)
+  will enable you to easily establish a code of conduct for your respective
+  open source community. The following is a code of conduct template. To
+  generate your own code of conduct, change the values of COMMUNITY, CONTACT
+  from their original values as given here, and substitute your own.</i></p>
+
+<div id="configure" class="unconfigured">
+  <a href="#configure" class="show-when-configured show-when-unconfigured">Configure</a>
+
+  <form class="show-when-configuring">
+    <p>
+      <label>Name of community:</label>
+      <input type="text" name="community">
+    </p>
+
+    <p>
+      <label>Email address to report abuses to:</label>
+      <input type="email" name="contact">
+    </p>
+
+    <button>Configure</button>
+  </form>
+
+
+  <div id="apply" class="show-when-configured">
+    <p>Copy and paste this template into the <code>README</code> or <code>CONTRIBUTING</code> file of your project.</p>
+
+    <textarea id="snippet"></textarea>
+
+    <div id="code"></div>
+  </div>
+
+  <script id="markdown-template" type="text/plain">
+    This project adheres to the [Open Code of Conduct]([URL]). By participating, you are expected to uphold this code.
+  </script>
+</div>
+
+<div id="code-of-conduct">
+  {{ content }}
+</div>
+
+<script type="text/javascript" src="{{site.baseurl }}/js/configure.js"></script>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -6,7 +6,8 @@
   <meta name="description" content="{{ site.description }}">
 
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <link rel="stylesheet" href="bootstrap.min.css" media="screen">
+  <link rel="stylesheet" href="{{site.baseurl }}/bootstrap.min.css" media="screen">
+  <link rel="stylesheet" href="{{site.baseurl }}/css/site.css" media="screen">
 </head>
 <body>
   <div class="container">

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -50,7 +50,9 @@
   <article id='article' class='page-{{page.title|downcase}}'>
     <div class="container">
       <div class="page-header">
-        <h1>{{ site.title }}</h1>
+        <h1>
+          <a href="{{ site.url }}">{{ site.title }}</a>
+        </h1>
         <h2>{{ site.description }}</h2>
       </div>
 

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -52,6 +52,7 @@
       <div class="page-header">
         <h1>
           <a href="{{ site.url }}">{{ site.title }}</a>
+          {% if page.version %}<span class="version">{{page.version}}</span>{% endif %}
         </h1>
         <h2>{{ site.description }}</h2>
       </div>

--- a/_sass/configure.scss
+++ b/_sass/configure.scss
@@ -1,5 +1,5 @@
 #configure {
-  background-color: #444;
+  background-color: #333;
   color: #ccc;
   border-top: 1px solid #eee;
   border-bottom: 1px solid #eee;
@@ -19,7 +19,7 @@
     ul li {
       float: left;
       width: 48%;
-      
+
       &:first-child {
         margin-right: 4%;
       }

--- a/_sass/configure.scss
+++ b/_sass/configure.scss
@@ -18,4 +18,5 @@
 #snippet {
   width: 100%;
   font-family: monospace;
+  height: 6em;
 }

--- a/_sass/configure.scss
+++ b/_sass/configure.scss
@@ -1,22 +1,85 @@
+.unconfigured .show-when-configured {
+  opacity: 0.5;
+}
 
 #configure {
-  & > * { display: none; }
+  background-color: #444;
+  color: #ccc;
+  border-top: 1px solid #eee;
+  border-bottom: 1px solid #eee;
+  padding: 1em 0;
+  margin: 2em 0;
 
-  &.unconfigured {
-    .show-when-unconfigured { display: block; }
+  .configured & {
+    display: none;
   }
 
-  &.configuring {
-    .show-when-configuring { display: block; }
+  ul {
+    overflow: hidden;
+    margin-top: 0;
   }
 
-  &.configured {
-    .show-when-configured { display: block; }
+  ul li {
+    float: left;
+    width: 50%;
+  }
+
+  ol {
+    counter-reset: configure-counter;
+    overflow: hidden;
+    margin: 0;
+    padding: 0;
+
+    & > li {
+      position: relative;
+      list-style: none;
+      padding-left: 48px;
+      margin: 2em 0;
+
+
+      h2 {
+        line-height: 36px;
+        margin-bottom: 0;
+        color: #fff;
+      }
+
+      &:before {
+        display: inline-block;
+        float: left;
+        position: absolute;
+        left: 0;
+        // top: 0;
+        width: 36px;
+        line-height: 36px;
+        font-size: 24px;
+        font-weight: bold;
+        border-radius: 36px;
+
+        text-align: center;
+        color: rgba(0,0,0,0.25);
+        color: #fff;
+        background: #A1D33C;
+
+        // Create a custom counter
+        content: counter(configure-counter);
+        counter-increment: configure-counter;
+      }
+    }
+  }
+}
+
+#apply {
+  opacity: 0.5;
+  transition: opacity 0.3s;
+
+  .configuring & {
+    opacity: 1;
   }
 }
 
 #snippet {
   width: 100%;
-  font-family: monospace;
-  height: 6em;
+  max-width: none;
+  font-size: 0.8em;
+  height: 8em;
 }

--- a/_sass/configure.scss
+++ b/_sass/configure.scss
@@ -1,0 +1,21 @@
+
+#configure {
+  & > * { display: none; }
+
+  &.unconfigured {
+    .show-when-unconfigured { display: block; }
+  }
+
+  &.configuring {
+    .show-when-configuring { display: block; }
+  }
+
+  &.configured {
+    .show-when-configured { display: block; }
+  }
+}
+
+#snippet {
+  width: 100%;
+  font-family: monospace;
+}

--- a/_sass/configure.scss
+++ b/_sass/configure.scss
@@ -1,7 +1,3 @@
-.unconfigured .show-when-configured {
-  opacity: 0.5;
-}
-
 #configure {
   background-color: #444;
   color: #ccc;
@@ -19,9 +15,20 @@
     margin-top: 0;
   }
 
-  ul li {
-    float: left;
-    width: 50%;
+  @media only screen and (min-width: 670px) {
+    ul li {
+      float: left;
+      width: 48%;
+      
+      &:first-child {
+        margin-right: 4%;
+      }
+
+      input {
+        width: 100%;
+        max-width: none;
+      }
+    }
   }
 
   ol {
@@ -48,7 +55,6 @@
         float: left;
         position: absolute;
         left: 0;
-        // top: 0;
         width: 36px;
         line-height: 36px;
         font-size: 24px;

--- a/css/site.scss
+++ b/css/site.scss
@@ -7,11 +7,3 @@
 article.page- h1 {
   font-size: 4em;
 }
-
-p#intro {
-  margin-left: 0;
-  font-size: 0.8em;
-  color: #777;
-  margin-bottom: 3em;
-  font-style: italic;
-}

--- a/css/site.scss
+++ b/css/site.scss
@@ -11,4 +11,10 @@ article.page- h1 {
     color: inherit;
     text-decoration: none;
   }
+
+  .version {
+    color: #333;
+    font-size: 18px;
+    font-weight: normal;
+  }
 }

--- a/css/site.scss
+++ b/css/site.scss
@@ -1,0 +1,5 @@
+---
+# Hey Jekyll, please transform this file.
+---
+
+@import "configure";

--- a/css/site.scss
+++ b/css/site.scss
@@ -6,4 +6,9 @@
 
 article.page- h1 {
   font-size: 4em;
+
+  a {
+    color: inherit;
+    text-decoration: none;
+  }
 }

--- a/index.md
+++ b/index.md
@@ -1,8 +1,7 @@
 ---
 layout: code-of-conduct
+version: v1.0
 ---
-
-## Open Code of Conduct v1.0
 
 This code of conduct outlines our expectations for participants within the **[COMMUNITY]** community, as well as steps to reporting unacceptable behavior. We are committed to providing a welcoming and inspiring community for all and expect our code of conduct to be honored.
 

--- a/index.md
+++ b/index.md
@@ -1,12 +1,10 @@
 ---
-layout: default
+layout: code-of-conduct
 ---
-
-_The purpose of creating this effort was to promote more open source organizations and projects to adopt code of conducts. Through our experiences at the [@TODOGroup](https://twitter.com/todogroup), we strongly believe that code of conducts help set the ground rules for participation in communities and more importantly, help build a culture of respect. We hope by [sharing this with you](https://github.com/opencodeofconduct/opencodeofconduct.github.io) will enable you to easily establish a code of conduct for your respective open source community. The following is a code of conduct template. To generate your own code of conduct, change the values of COMMUNITY, CONTACT from their original values as given here, and substitute your own._
 
 ### Open Code of Conduct v1.0
 
-This code of conduct outlines our expectations for participants within the **[COMMUNITY]**, as well as steps to reporting unacceptable behavior. We are committed to providing a welcoming and inspiring community for all and expect our code of conduct to be honored.
+This code of conduct outlines our expectations for participants within **[COMMUNITY]**, as well as steps to reporting unacceptable behavior. We are committed to providing a welcoming and inspiring community for all and expect our code of conduct to be honored.
 
 Our open source community strives to:
 

--- a/index.md
+++ b/index.md
@@ -4,7 +4,7 @@ layout: code-of-conduct
 
 ### Open Code of Conduct v1.0
 
-This code of conduct outlines our expectations for participants within **[COMMUNITY]**, as well as steps to reporting unacceptable behavior. We are committed to providing a welcoming and inspiring community for all and expect our code of conduct to be honored.
+This code of conduct outlines our expectations for participants within the **[COMMUNITY]** community, as well as steps to reporting unacceptable behavior. We are committed to providing a welcoming and inspiring community for all and expect our code of conduct to be honored.
 
 Our open source community strives to:
 

--- a/js/configure.coffee
+++ b/js/configure.coffee
@@ -10,6 +10,12 @@ class @Configure
     @form.addEventListener "submit", @submit
     @element.querySelector("a[href='#configure']").addEventListener "click", @start
 
+    if data = @decode(window.location.hash.substr(1))
+      @template.configure(data)
+
+      # Fill out configuration form with values so it can be edited
+      @form.elements.namedItem(key)?.value = value for key,value of data
+
   start: (event) =>
     event.preventDefault()
     @element.classList.add("configuring")
@@ -45,7 +51,8 @@ class @Configure
     btoa(escaped)
 
   decode: (string) ->
-    JSON.parse(atob(string))
+    try
+      JSON.parse(atob(string))
 
 class Template
   constructor: (@element) ->

--- a/js/configure.coffee
+++ b/js/configure.coffee
@@ -1,0 +1,70 @@
+---
+# Hey Jekyll, please transform this file.
+---
+
+class @Configure
+  constructor: (@template, @element) ->
+    @form = @element.querySelector("form")
+    @snippet = @element.querySelector("#snippet")
+
+    @form.addEventListener "submit", @submit
+    @element.querySelector("a[href='#configure']").addEventListener "click", @start
+
+  start: (event) =>
+    event.preventDefault()
+    @element.classList.add("configuring")
+    @element.classList.remove("unconfigured")
+    @element.classList.remove("configured")
+
+  submit: (event) =>
+    event.preventDefault()
+    @setup @data()
+    @element.classList.remove("configuring")
+    @element.classList.add("configured")
+
+  # Return the form data as an object
+  data: ->
+    data = {}
+    for element in @form.elements
+      data[element.name] = element.value if element.value.length
+    data
+
+  setup: (data) ->
+    @template.configure(data)
+    window.location.hash = @encode(data)
+
+    snippet = @element.querySelector("#markdown-template").innerText.trim()
+    snippet = snippet.replace("[URL]", window.location)
+    @snippet.value = snippet
+
+  encode: (data) ->
+    # Base64 encode the data, escaping non-ascii characters.
+    # https://developer.mozilla.org/en-US/docs/Web/API/WindowBase64/Base64_encoding_and_decoding#The_.22Unicode_Problem.22
+    str = encodeURIComponent(JSON.stringify(data))
+    escaped = str.replace /%([0-9A-F]{2})/g, (match, p1) -> String.fromCharCode('0x' + p1)
+    btoa(escaped)
+
+  decode: (string) ->
+    JSON.parse(atob(string))
+
+class Template
+  constructor: (@element) ->
+
+  configure: (data) ->
+    # Make a backup copy so this can be run multiple times
+    @original ?= @element.cloneNode(true)
+
+    node = @original.cloneNode(true)
+
+    placeholders = {}
+    placeholders["[#{key.toUpperCase()}]"] = value for key, value of data
+
+    for element in node.querySelectorAll("strong")
+      for key, value of placeholders
+        element.textContent = value if element.textContent == key
+
+    @element.parentNode.replaceChild(node, @element)
+    @element = node
+
+template = new Template(element) if element = document.querySelector("#code-of-conduct")
+new Configure(template, element) if element = document.getElementById("configure")

--- a/js/configure.coffee
+++ b/js/configure.coffee
@@ -8,26 +8,27 @@ class @Configure
     @snippet = @element.querySelector("#snippet")
 
     @form.addEventListener "submit", @submit
-    @element.querySelector("a[href='#configure']").addEventListener "click", @start
+
+    for input in @form.querySelectorAll("input")
+      input.addEventListener "keypress", @check
 
     if data = @decode(window.location.hash.substr(1))
       @template.configure(data)
 
       # Fill out configuration form with values so it can be edited
       @form.elements.namedItem(key)?.value = value for key,value of data
-      @element.classList.remove("unconfigured")
+      document.body.classList.add("configured")
 
-  start: (event) =>
-    event.preventDefault()
-    @element.classList.add("configuring")
-    @element.classList.remove("unconfigured")
-    @element.classList.remove("configured")
+  check: =>
+    clearTimeout(@timeout) if @timeout
+    @timeout = setTimeout(@submit, 250)
 
   submit: (event) =>
-    event.preventDefault()
+    return unless @form.checkValidity()
+    event?.preventDefault()
+
     @setup @data()
-    @element.classList.remove("configuring")
-    @element.classList.add("configured")
+    document.body.classList.add("configuring")
 
   # Return the form data as an object
   data: ->
@@ -43,6 +44,7 @@ class @Configure
     snippet = @element.querySelector("#markdown-template").innerText.trim()
     snippet = snippet.replace("[URL]", window.location)
     @snippet.value = snippet
+    @snippet.setAttribute("disabled", false)
 
   encode: (data) ->
     # Base64 encode the data, escaping non-ascii characters.

--- a/js/configure.coffee
+++ b/js/configure.coffee
@@ -10,8 +10,8 @@ class @Configure
     @form = @element.querySelector("form")
     @snippet = @element.querySelector("#snippet")
 
-    # Copy the snippet text on focus
-    @snippet.addEventListener "focus", @copy
+    # Select the snippet text on focus
+    @snippet.addEventListener "focus", -> @select()
     # Prevent mouseup from unselecting the text
     @snippet.addEventListener "mouseup", (e) -> e.preventDefault()
 
@@ -71,10 +71,6 @@ class @Configure
     data = {}
     data[key] = values[index] for key,index in @constructor.variables
     data
-
-  copy: (event) =>
-    event.target.select()
-    document.execCommand('copy')
 
 class Template
   constructor: (@element) ->

--- a/js/configure.coffee
+++ b/js/configure.coffee
@@ -3,6 +3,9 @@
 ---
 
 class @Configure
+  # Variables that get encoded in the URL and substituted in the template
+  @variables: ["community", "contact"]
+
   constructor: (@template, @element) ->
     @form = @element.querySelector("form")
     @snippet = @element.querySelector("#snippet")
@@ -54,16 +57,14 @@ class @Configure
 
   # Encode the configuration data
   encode: (data) ->
-    # Base64 encode the data, escaping non-ascii characters.
-    # https://developer.mozilla.org/en-US/docs/Web/API/WindowBase64/Base64_encoding_and_decoding#The_.22Unicode_Problem.22
-    str = encodeURIComponent(JSON.stringify(data))
-    escaped = str.replace /%([0-9A-F]{2})/g, (match, p1) -> String.fromCharCode('0x' + p1)
-    btoa(escaped)
+    (encodeURIComponent(data[key]) for key in @constructor.variables).join("/")
 
   # Decode the configuration data
   decode: (string) ->
-    try
-      JSON.parse(atob(string))
+    values = string.split("/")
+    data = {}
+    data[key] = values[index] for key,index in @constructor.variables
+    data
 
 class Template
   constructor: (@element) ->

--- a/js/configure.coffee
+++ b/js/configure.coffee
@@ -15,6 +15,7 @@ class @Configure
 
       # Fill out configuration form with values so it can be edited
       @form.elements.namedItem(key)?.value = value for key,value of data
+      @element.classList.remove("unconfigured")
 
   start: (event) =>
     event.preventDefault()

--- a/js/configure.coffee
+++ b/js/configure.coffee
@@ -62,7 +62,7 @@ class @Configure
 
   # Encode the configuration data
   encode: (data) ->
-    (encodeURIComponent(data[key]) for key in @constructor.variables).join("/")
+    (data[key] for key in @constructor.variables).join("/")
 
   # Decode the configuration data
   decode: (string) ->

--- a/js/configure.coffee
+++ b/js/configure.coffee
@@ -10,10 +10,15 @@ class @Configure
     @form = @element.querySelector("form")
     @snippet = @element.querySelector("#snippet")
 
+    # Copy the snippet text on focus
+    @snippet.addEventListener "focus", @copy
+    # Prevent mouseup from unselecting the text
+    @snippet.addEventListener "mouseup", (e) -> e.preventDefault()
+
     # Listen to form events to update the snippet
     @form.addEventListener "submit", @submit
     for input in @form.querySelectorAll("input")
-      input.addEventListener "keypress", @keypress
+      input.addEventListener "keyup", @keypress
 
     # If the URL has config variables, update the tempalate
     if data = @decode(window.location.hash.substr(1))
@@ -53,7 +58,7 @@ class @Configure
     snippet = @element.querySelector("#markdown-template").innerText.trim()
     snippet = snippet.replace("[URL]", window.location)
     @snippet.value = snippet
-    @snippet.setAttribute("disabled", false)
+    @snippet.disabled = false
 
   # Encode the configuration data
   encode: (data) ->
@@ -66,6 +71,10 @@ class @Configure
     data = {}
     data[key] = values[index] for key,index in @constructor.variables
     data
+
+  copy: (event) =>
+    event.target.select()
+    document.execCommand('copy')
 
 class Template
   constructor: (@element) ->

--- a/js/configure.coffee
+++ b/js/configure.coffee
@@ -61,6 +61,7 @@ class @Configure
 
   # Decode the configuration data
   decode: (string) ->
+    return if string == ""
     values = string.split("/")
     data = {}
     data[key] = values[index] for key,index in @constructor.variables


### PR DESCRIPTION
The Code of Conduct will gain more adoption if it's easy for maintainers to adopt it. Some projects may still want to fork it and make more drastic changes, but for a significant portion of the community, the standard template will suffice. This is an attempt to demonstrate what was suggested in #7:

![configure](https://cloud.githubusercontent.com/assets/173/8442162/0dbc8028-1f4b-11e5-9616-2019073f8ef1.gif)

_Updated gif, [here is the original](https://cloud.githubusercontent.com/assets/173/8343205/8a6c3594-1a98-11e5-93a8-ede262a98b14.gif)_

If we want to go this route, there's still some more work to do here:
- [x] Clean up the JavaScript
- [x] Design it
- [x] ZeroClipboard to make it easier to copy the snippet
- [x] Better way to encode config data

What do you think?

/cc @caniszczyk 
