### PR TITLE
Clean up attribution

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,12 +54,4 @@ See this XKCD for our feelings on this matter: https://xkcd.com/1357/
 
 ## Thanks
 
-We all stand on the shoulders of giants across many open source communities. 
-
-We'd like to thank the communities and projects that established code of conducts and diversity statements as our inspiration:
-* Django: https://www.djangoproject.com/conduct/reporting/
-* Python: https://www.python.org/community/diversity/
-* Ubuntu: http://www.ubuntu.com/about/about-ubuntu/conduct
-* Contributor Covenant: http://contributor-covenant.org/
-* Geek Feminism: http://geekfeminism.org/about/code-of-conduct/
-
+We all stand on the shoulders of giants across many open source communities. We'd like to thank the [communities and projects that established code of conducts and diversity statements](http://todogroup.org/opencodeofconduct/#attribution--acknowledgements) as our inspiration.

--- a/index.md
+++ b/index.md
@@ -46,12 +46,11 @@ Anyone asked to stop unacceptable behavior is expected to comply immediately. If
 
 ### Attribution & Acknowledgements
 
-We all stand on the shoulders of giants across many open source communities. 
+We all stand on the shoulders of giants across many open source communities.  We'd like to thank the communities and projects that established code of conducts and diversity statements as our inspiration:
 
-We'd like to thank the communities and projects that established code of conducts and diversity statements as our inspiration:
-* Django: https://www.djangoproject.com/conduct/reporting/
-* Python: https://www.python.org/community/diversity/
-* Ubuntu: http://www.ubuntu.com/about/about-ubuntu/conduct
-* Contributor Covenant: http://contributor-covenant.org/
-* Geek Feminism: http://geekfeminism.org/about/code-of-conduct/
-* Citizen Code of Conduct: http://citizencodeofconduct.org/
+* [Django](https://www.djangoproject.com/conduct/reporting/)
+* [Python](https://www.python.org/community/diversity/)
+* [Ubuntu](http://www.ubuntu.com/about/about-ubuntu/conduct)
+* [Contributor Covenant](http://contributor-covenant.org/)
+* [Geek Feminism](http://geekfeminism.org/about/code-of-conduct/)
+* [Citizen Code of Conduct](http://citizencodeofconduct.org/)


### PR DESCRIPTION
This cleans up some formatting on the attribution section, and removes the duplication of the credits.
## Before

<img width="765" alt="open_code_of_conduct" src="https://cloud.githubusercontent.com/assets/173/8788025/793051da-2eec-11e5-9415-38b660e574b6.png">
## After

<img width="733" alt="open_code_of_conduct" src="https://cloud.githubusercontent.com/assets/173/8788058/adc45fcc-2eec-11e5-9227-cab14358da94.png">
