### PR TITLE
Removes unwelcoming language

### DIFF
--- a/index.md
+++ b/index.md
@@ -34,9 +34,8 @@ Harassment includes, but is not limited to:
 - Deliberate “outing” of any aspect of a person’s identity without their consent except as necessary to protect others from intentional abuse
 - Publication of non-harassing private communication
 
-Our open source community prioritizes marginalized people’s safety over privileged people’s comfort. We will not act on complaints regarding:
+We will not act on complaints regarding:
 
-- ‘Reverse’ -isms, including ‘reverse racism,’ ‘reverse sexism,’ and ‘cisphobia’
 - Reasonable communication of boundaries, such as “leave me alone,” “go away,” or “I’m not discussing this with you”
 - Refusal to explain or debate social justice concepts
 - Communicating in a ‘tone’ you don’t find congenial


### PR DESCRIPTION
Fixes #40
PR that introduced the removed content: #17 
Edit:

The intent of this pr is to preserve the welcoming nature of the repos that use it. Regardless of any discussion or debate on rather reverse racism exists, or any discussion or debate on the exact definition of discrimination, language that excludes entire classes from anti-discrimination clauses creates an unwelcoming, impolite, and potentially hostile environment. 

I should probably ping @ammeep in here, since it is their change that is getting partially reverted.

Edit:
This thread has been locked, because that is literally meaningless:
# Feel free to continue discussion at: https://github.com/MrStonedOne/opencodeofconduct/pull/1

**_I will edit all comments from there into this comment**_ (maybe some day @bkeepers will learn that you just can't stop the signal, you can never stop the signal.)

---

---

just3ws:
+1

---

thor:

> The intent of the open code of conduct is to help establish communities that are safe and welcoming for _everyone_. At some point, the moderators of a community are going to have to make tradeoffs. The language in question is attempting to guide how those tradeoffs are prioritized, not to encourage hostility.

I am having a hard time seeing how creating a biased discrimination filter creates a safe and welcoming community for _everyone_ -- would it not be ideal to establish a absolutely fair and even set of guidelines that apply to _everyone_ if one wants _everyone_ to be equally safe and welcome? :unlock: 

> [..] if we can clarify the language to communicate that.

Hopefully there is a way to clarify that without imposing perceived biases on communities as a default?

---

MrStonedOne:
@bkeepers:

> The intent of the open code of conduct is to help establish communities that are safe and welcoming for everyone. 

Yep! Everyone.

> At some point, the moderators of a community are going to have to make tradeoffs. 

[citation needed] You disallow discrimination, and you disallow discriminatory language, no trade off necessary.

> The language in question is attempting to guide how those tradeoffs are prioritized, not to encourage hostility.

Again, not needed. There are no tradeoffs involved, this isn't a zero sum game.

> I will seek feedback from people that have been invested in crafting and adopting this document to see if we can clarify the language to communicate that.

And I'm going to insist that there is no way such "priority" can co-exist with a safe and welcoming environment.

> I am also going to lock this thread while I do that.

I see no need for this, and it's easily thwarted. This seems like you trying to ensure you got the final word in.

> Know that your feedback is being taken seriously.

Heh. Is that why you locked the pr in an attempt to ensure your privileged position in the discussion. Get the final word in, and call it good. "but know that your feedback is being taken seriously" The tried and true words of people who want to silence criticisms they aren't comfortable with.

---

ELLIOTTCABLE:
Wow, this is fucking ridiculous.

The creators and maintainers of _this project_ have made themselves clear to you, @MrStonedOne (your name, too … just, wow.) They offered to take your concerns seriously (more, by the way, than they are _in any way_ obligated to do), but it's entirely their right (and a damned good decision) to shut down the potentially-unproductive discussion while they decide whether they're compfortable making those changes.

This is an open-source document; you're welcome to fork it, if the maintainers end up disagreeing with you; and tell people of your concerns with the original / point out your forked efforts at improvement.

Pulling _this_ “ooo my freedom of speech is being quashed!!1!” stuff is a really good way to get those concerns ignored completely. Well done, sir, well done.

---

MrStonedOne:

> Pulling this “ooo my freedom of speech is being quashed!!1!”

Actually, I said they tried to stop discussion, nothing about free speech.

> your name, too … just, wow.

Some people drink alcohol, they might even make a username on that, some people smoke weed (and they too might make a username on that) I see no issue, it's all 21+ legal, so whats the issue? I'm over 21(25), I am legally allowed to smoke marijuana, and I refuse to make it a secret part of me because somebody wants to use it as an excuse to look down at me. 

---

KelseyDH:
:+1: 

---

apullin:
:+1:

In the other threads, I have seen it stated that it is a non-starter to discuss the material nature of the items being removed. There should be a motion for estoppel with whichever pertinent committed or governing bodies for the project, with respect to the inclusion of any disputed elements being included. Hiding one dispute behind another is poor design and leadership.

If GitHub intends to adopt this policy, then I am de facto directly involved with it, as I have made agreements, both contractual and financial, with GitHub. The is true for organization that stated intent to adopt this document, and for any persons who have any transactions or contracts with them.

@ELLIOTTCABLE, you are personalizing this is a fruitless way. I am certain that I have done myself this with difficult issues in the past. I only offer this to try and level the hotness of the personal politics that pervade this issue.

---

tkerber:
:+1:

I cannot see myself contributing to any project using the open code of conduct unless this is removed.

I do not think that todogroup should inject their own ideology into a document which is supposed to protect **people**.

---

ceph3us:
:+1:

The spirit of open source is to allow equal access to all without qualification or discrimination, and a company whose business in invested in it should follow those principles. A community seeking to be accessible to everyone should not promote a one way street on the policing of negative behaviour.

---

Karunamon:
+1

This kind of nonsense seriously impacts my desire to use Github for any projects, personal or otherwise, in the future. It's clear the site leadership values ideology more than Getting Shit Done©

---

arthurkay:
Codes of conduct are not a means for legitimizing people being abusive online. They're meant to stop that. And the old Open Code did. Please do not grant special protections to abusive users like https://github.com/freebsdgirl

---

j-wo-:
:+1:

This kind of language only serves to antagonize every person who does not share the ideology of the authors, and it would be foolish for any project to alienate a great number of people by including it.
