### PR TITLE
Replace language targeting groups with general principles

### DIFF
--- a/index.md
+++ b/index.md
@@ -33,10 +33,11 @@ Harassment includes, but is not limited to:
 - Continued one-on-one communication after requests to cease
 - Deliberate “outing” of any aspect of a person’s identity without their consent except as necessary to protect others from intentional abuse
 - Publication of non-harassing private communication
+ 
+Everybody has their own personal background, family history and culture. What's normal to one person can be intimidating to another and what one person sees as an unreasonable imposition could be a nessessity to somebody else. When a complaint is made we pledge to push beyond own biases, to strive to try to see the issue from every point of view, and to make the accommodations that allow a diverse community to thrive. 
 
-Our open source community prioritizes marginalized people’s safety over privileged people’s comfort. We will not act on complaints regarding:
+We will not act on complaints regarding:
 
-- ‘Reverse’ -isms, including ‘reverse racism,’ ‘reverse sexism,’ and ‘cisphobia’
 - Reasonable communication of boundaries, such as “leave me alone,” “go away,” or “I’m not discussing this with you”
 - Refusal to explain or debate social justice concepts
 - Communicating in a ‘tone’ you don’t find congenial


### PR DESCRIPTION
At the end of pull request #56 @bkeepers explained the thinking behind this template code of conduct. 

In the interest of being constructive in my criticism here is my proposal for a CoC that fits his aims. If @bkeepers wishes to lock this comment thread too pending the unlock of pull request #56 - then be my guest. 

---

My goal with this was to not single out any particular group as being an "acceptable target", to me even the concept of someone being an acceptable target is enough to make a convention feel actively hostile. 

I believe this captures as much of the original intent as possible without explicitly referring to any group. 

(tagging in @MrStonedOne @ammeep )
