### PR TITLE
expand list of unprotected classes

### DIFF
--- a/index.md
+++ b/index.md
@@ -36,7 +36,7 @@ Harassment includes, but is not limited to:
 
 Our open source community prioritizes marginalized people’s safety over privileged people’s comfort. We will not act on complaints regarding:
 
-- ‘Reverse’ -isms, including ‘reverse racism,’ ‘reverse sexism,’ and ‘cisphobia’
+- ‘Reverse’ -isms, including ‘reverse racism,’ ‘reverse sexism,’ ’heterophobia,’ ‘cisphobia,’ and ’pro-semitism’
 - Reasonable communication of boundaries, such as “leave me alone,” “go away,” or “I’m not discussing this with you”
 - Refusal to explain or debate social justice concepts
 - Communicating in a ‘tone’ you don’t find congenial


### PR DESCRIPTION
adds 'heterophobia' and 'pro-semitism' to the list, which currently includes 'reverse racism,' 'reverse sexism,' and 'cisphobia.'
