### PR TITLE
Narrow scope of ignored complaints, state intent

### DIFF
--- a/index.md
+++ b/index.md
@@ -34,14 +34,13 @@ Harassment includes, but is not limited to:
 - Deliberate “outing” of any aspect of a person’s identity without their consent except as necessary to protect others from intentional abuse
 - Publication of non-harassing private communication
 
-Our open source community prioritizes marginalized people’s safety over privileged people’s comfort. We will not act on complaints regarding:
+Our open source community prioritizes the right to feel safe over the right to feel comfortable; that is, if we have to decide between one person feeling less comfortable and one person feeling less safe, we will side with feeling safer.
 
-- ‘Reverse’ -isms, including ‘reverse racism,’ ‘reverse sexism,’ and ‘cisphobia’
-- Reasonable communication of boundaries, such as “leave me alone,” “go away,” or “I’m not discussing this with you”
-- Refusal to explain or debate social justice concepts
+We will not act on complaints regarding somebody:
+
+- Reasonably communicating boundaries, such as “leave me alone,” “go away,” or “I’m not discussing this with you”
+- Refusing to explain or debate social justice concepts
 - Communicating in a ‘tone’ you don’t find congenial
-- Criticizing racist, sexist, cissexist, or otherwise oppressive behavior or assumptions
-
 
 ### Diversity Statement
 


### PR DESCRIPTION
This hopefully solves the reverse-isms debate in a clean and succinct way, by moving the reverse-isms from a "nah we won't even act on that" into a judgement call with a clear statement of intent.

This came from a goal to simplify the solution proposed in #68 

I also changed the phrasing of the bulleted list so it's not just "regarding" and more concretely describes the applicable situations — a user doing X

I also removed "Criticizing racist, sexist, cissexist, or otherwise oppressive behavior or assumptions" because it's an easy loophole for trolls to abuse in starting a debate and should be covered already by the rest of the CoC
