### PR TITLE
Removed protection for cisphobic and racist individuals

### DIFF
--- a/index.md
+++ b/index.md
@@ -34,13 +34,12 @@ Harassment includes, but is not limited to:
 - Deliberate “outing” of any aspect of a person’s identity without their consent except as necessary to protect others from intentional abuse
 - Publication of non-harassing private communication
 
-Our open source community prioritizes marginalized people’s safety over privileged people’s comfort. We will not act on complaints regarding:
+Our open source community prioritizes people’s safety over people’s comfort. We will not act on complaints regarding:
 
-- ‘Reverse’ -isms, including ‘reverse racism,’ ‘reverse sexism,’ and ‘cisphobia’
 - Reasonable communication of boundaries, such as “leave me alone,” “go away,” or “I’m not discussing this with you”
 - Refusal to explain or debate social justice concepts
 - Communicating in a ‘tone’ you don’t find congenial
-- Criticizing racist, sexist, cissexist, or otherwise oppressive behavior or assumptions
+- Criticizing racist, sexist, or otherwise oppressive behavior or assumptions
 
 
 ### Diversity Statement


### PR DESCRIPTION
There should be no difference in policy between 'marginalized' and 'privileged' individuals, because offering protection to one group and not another based on their gender, gender identity and expression, sexual orientation, disability, mental illness, neuro(a)typicality, physical appearance, body size, race, age, regional discrimination, political or religious affiliation is defined as harassment.

There is no real way to determine whether someone is 'privileged' or not, and regardless should not be offered less protection because of it.
Reverse racism exists as regular racism, and there should be no protection for racists just because they're being racist against a 'privileged' group. It's still racism and should not be tolerated.
