### PR TITLE
textContent instead of innerText when available

### DIFF
--- a/js/configure.coffee
+++ b/js/configure.coffee
@@ -55,7 +55,7 @@ class @Configure
     @template.configure(data)
     window.location.hash = @encode(data)
 
-    snippet = @element.querySelector("#markdown-template").innerText.trim()
+    snippet = @element.querySelector("#markdown-template")['textContent' in @element ? 'textContent' : 'innerText'].trim()
     snippet = snippet.replace("[URL]", window.location)
     @snippet.value = snippet
     @snippet.disabled = false


### PR DESCRIPTION
Fixes #88 and shouldn't affect the site (it falls back to using `innerText` if `textContent` is not supported).

Gecko does not support `innerText`, but Internet Explorer 9+ supports `textContent`, as does Chrome; see https://developer.mozilla.org/en-US/docs/Web/API/Node/textContent.
DOM 3, DOM4, and DOM all define `textContent`, while `innerText` is a propriety Internet Explorer extension supported by Chrome and Opera for compatibility with MSIE.
