### PR TITLE
Added questioning of disabilities to list of harassing behaviours

### DIFF
--- a/index.md
+++ b/index.md
@@ -33,6 +33,7 @@ Harassment includes, but is not limited to:
 - Continued one-on-one communication after requests to cease
 - Deliberate “outing” of any aspect of a person’s identity without their consent except as necessary to protect others from intentional abuse
 - Publication of non-harassing private communication
+- Questioning how genuine a disability/health issue is
 
 Our open source community prioritizes marginalized people’s safety over privileged people’s comfort. We will not act on complaints regarding:
 


### PR DESCRIPTION
Sometimes people with disabilities are questioned as to how real or genuine their condition is. Sometimes people with medical problems are dismissed as having some kind of mental illness (e.g. transphobic comments about it being a temporary delusional state).
